### PR TITLE
Improved Composer Support

### DIFF
--- a/bin/gvs
+++ b/bin/gvs
@@ -10,7 +10,7 @@ YELLOW="\033[0;33m"
 GREEN="\033[0;32m"
 CYAN="\033[0;36m"
 
-function usage_info() {
+function echo_usage_info() {
   echo "git version switcher: Checkout specific branch|commit|tag on targets"
   echo
   echo "Usage: $(basename "$0") [-h] [-u] [-r] [-v] <TARGET1> [TARGET2…]"
@@ -21,6 +21,12 @@ function usage_info() {
   echo "   TARGET               Path and branch|commit|tag separated by a colon (:)"
 }
 
+verbose_only_echo() {
+  if $VERBOSE_OUTPUT; then
+    echo "$@"
+  fi
+}
+
 get_phpunit_version() {
   if [ -f "$CWD/vendor/bin/phpunit" ]; then
     PU=$("$CWD/vendor/bin/phpunit" --version | awk '{print $2}')
@@ -29,30 +35,51 @@ get_phpunit_version() {
   else
     PU="N/A"
   fi
-  echo $PU
+  echo "$PU"
 }
 
-environment_info() {
+echo_environment_info() {
   PHP_V=$(php -r "echo PHP_VERSION, \"\n\";")
   if php -i | grep -q "xdebug support"; then XD=enabled; else XD=disabled; fi
   PU=$(get_phpunit_version)
   echo -e "${GREEN}PHP: $YELLOW$PHP_V, ${GREEN}Xdebug: $YELLOW$XD, ${GREEN}PHPUnit: $YELLOW$PU$NC"
 }
 
-remove_uncommitted_composer_lock_file() {
-  if [ -f "$DIR/composer.lock" ] && [ $(git status --porcelain composer.lock | wc -l) -ne "0" ]; then
-    $VERBOSE_OUTPUT && echo "$DIR/composer.lock is not committed to git. Deleting."
-    rm -f "$DIR/composer.lock"
+composer_install() {
+  # Directories to look for a composer.json file in.
+  if [ -f "$REPO_PATH/composer.json" ]; then
+    COMPOSER_DIR=$REPO_PATH
+  elif [ -f "$REPO_PATH/plugins/woocommerce/composer.json" ]; then
+    COMPOSER_DIR=$REPO_PATH/plugins/woocommerce
+  else
+    verbose_only_echo "No composer.json found in $REPO_PATH"
+    verbose_only_echo "No composer install needed."
+    return
   fi
-}
-remove_vendor() {
-  rm -rf "$DIR/vendor"
-  $VERBOSE_OUTPUT && echo "$DIR/vendor deleted."
+
+  cd "$COMPOSER_DIR" || exit 1
+  verbose_only_echo "$COMPOSER_DIR/composer.json exists."
+
+  if [ -d "vendor" ]; then
+    verbose_only_echo "$COMPOSER_DIR/vendor is committed to git."
+    verbose_only_echo "No composer install needed."
+    return
+  fi
+
+  verbose_only_echo "Install composer packages to $(pwd)"
+
+  if ! composer install --no-interaction --no-dev --quiet; then
+    verbose_only_echo "Composer install failed. Retrying with \`--ignore-platform-reqs.\`"
+    composer install --no-interaction --no-dev --quiet --ignore-platform-reqs --no-interaction
+    verbose_only_echo "Alternative composer install completed."
+  fi
+
+  verbose_only_echo "Composer install completed."
 }
 
 if [ $# -lt 1 ]; then
   echo Arguments missing!
-  usage_info
+  echo_usage_info
   exit 1
 fi
 
@@ -68,7 +95,7 @@ while [ -n "$1" ]; do
     DO_CHECKOUT=false
     ;;
   --help | -h)
-    usage_info
+    echo_usage_info
     exit
     ;;
   *)
@@ -93,56 +120,21 @@ for REPO in "${REPOSITORIES[@]}"; do
 
   # Update (fetch)
   if $DO_UPDATE; then
-    $VERBOSE_OUTPUT && echo "Update from remote (fetch) for $(pwd)" || true
+    verbose_only_echo "Update from remote (fetch) for $(pwd)"
     git fetch --tags --force
   fi
 
   # Checkout
   if $DO_CHECKOUT; then
+    # Reset to clean state.
+    # See: https://stackoverflow.com/a/1090316
+    git reset --hard
+    git clean -fxd
+
     # Checkout target
     git checkout --force --quiet "$REPO_TARGET"
 
-    # Directories to look for a composer.json file in
-    DIRS=("$REPO_PATH" "$REPO_PATH/plugins/woocommerce")
-    for DIR in "${DIRS[@]}"; do
-      if [ -f "$DIR/composer.json" ]; then
-        $VERBOSE_OUTPUT && echo "composer.json exists at $DIR/composer.json"
-        cd "$DIR" || exit 1
-
-        # Clean up files and then install composer dependencies
-        remove_uncommitted_composer_lock_file
-
-        if [ -d "$DIR/plugins" ] && [ $(git status --porcelain | grep "plugins/" | wc -l) -ne "0" ]; then
-          rm -rf "$DIR/plugins"
-          $VERBOSE_OUTPUT && echo "$DIR/plugins from WC monorepo deleted."
-        fi
-        if [ -d "$DIR/vendor" ]; then
-          $VERBOSE_OUTPUT && echo "$DIR/vendor exists."
-          if [ ! -f "$DIR/vendor/autoload.php" ] && [ ! -f "$DIR/vendor/autoload_packages.php" ]; then
-            # Older WooCommerce versions such as 4.7.x have vendor committed, but without the necessary dependencies.
-            $VERBOSE_OUTPUT && echo "$DIR/vendor/ has no autoloader file."
-            remove_vendor
-          elif [ $(git status --porcelain vendor | wc -l) -eq "0" ]; then
-            $VERBOSE_OUTPUT && echo "$DIR/vendor is committed to git, so no composer install required. Skipping."
-            break
-          else
-            remove_vendor
-          fi
-        fi
-
-        remove_uncommitted_composer_lock_file
-
-        $VERBOSE_OUTPUT && echo "Install composer packages to $(pwd)" || true
-        if composer install --no-suggest --no-dev --quiet; then
-          $VERBOSE_OUTPUT && echo "Composer install completed."
-        else
-          $VERBOSE_OUTPUT && echo "Composer install failed. Retrying with --ignore-platform-reqs."
-          composer install --no-suggest --no-dev --quiet --ignore-platform-reqs --no-interaction
-          $VERBOSE_OUTPUT && echo "Alternative composer install completed."
-        fi
-      fi
-    done
-
+    composer_install
   fi
 
   # Report target
@@ -151,5 +143,5 @@ for REPO in "${REPOSITORIES[@]}"; do
 done
 
 if $VERBOSE_OUTPUT; then
-  environment_info
+  echo_environment_info
 fi

--- a/bin/gvs
+++ b/bin/gvs
@@ -40,7 +40,7 @@ environment_info() {
 }
 
 remove_uncommitted_composer_lock_file() {
-  if [ -f "$DIR/composer.lock" ] && [ $(git ls-files composer.lock | wc -l) -eq "0" ]; then
+  if [ -f "$DIR/composer.lock" ] && [ $(git status --porcelain composer.lock | wc -l) -ne "0" ]; then
     $VERBOSE_OUTPUT && echo "$DIR/composer.lock is not committed to git. Deleting."
     rm -f "$DIR/composer.lock"
   fi
@@ -108,13 +108,13 @@ for REPO in "${REPOSITORIES[@]}"; do
         # Clean up files and then install composer dependencies
         remove_uncommitted_composer_lock_file
 
-        if [ -d "$DIR/plugins" ] && [ $(git status --porcelain | grep plugins/ | wc -l) -ne "0" ]; then
+        if [ -d "$DIR/plugins" ] && [ $(git status --porcelain | grep "plugins/" | wc -l) -ne "0" ]; then
           rm -rf "$DIR/plugins"
           $VERBOSE_OUTPUT && echo "$DIR/plugins from WC monorepo deleted."
         fi
         if [ -d "$DIR/vendor" ]; then
           $VERBOSE_OUTPUT && echo "$DIR/vendor exists"
-          if [ $(git ls-files vendor | wc -l) -ne "0" ]; then
+          if [ $(git status --porcelain vendor | wc -l) -eq "0" ]; then
             $VERBOSE_OUTPUT && echo "$DIR/vendor is committed to git, so no composer install required. Skipping."
             break
           else

--- a/bin/gvs
+++ b/bin/gvs
@@ -134,7 +134,12 @@ for REPO in "${REPOSITORIES[@]}"; do
         $VERBOSE_OUTPUT && echo "$dir/composer.lock is not committed to git. Deleted."
       fi
       $VERBOSE_OUTPUT && echo "Install composer packages to $(pwd)" || true
-      composer install --no-suggest --no-dev --quiet
+      if composer install --no-suggest --no-dev --quiet ; then
+        $VERBOSE_OUTPUT && echo "Composer install completed."
+      else
+        $VERBOSE_OUTPUT && echo "Composer install failed. Retrying with --ignore-platform-reqs."
+        composer install --no-suggest --no-dev --quiet --ignore-platform-reqs
+      fi
       cd "$REPO_PATH"
      fi
     done

--- a/bin/gvs
+++ b/bin/gvs
@@ -95,42 +95,50 @@ for REPO in "${REPOSITORIES[@]}"; do
 
   # Checkout
   if $DO_CHECKOUT; then
-    # Delete composer dependencies from WooCommerce
-    if [ -f plugins/woocommerce/woocommerce.php ] || [ -f woocommerce.php ]; then
-      if [ -f plugins/woocommerce/woocommerce.php ]; then
-        # WooCommerce 6.0+ monorepo where composer.json is in plugins/woocommerce/composer.json
-        cd plugins/woocommerce
-      fi
-      $VERBOSE_OUTPUT && echo "Delete composer packages from $(pwd)" || true
-      rm -f composer.lock && rm -rf vendor
-      cd "$REPO_PATH"
-    fi
-
     # Checkout target
     git checkout --force --quiet "$REPO_TARGET"
 
-    # Install composer dependencies for WooCommerce
-    if [ -f plugins/woocommerce/woocommerce.php ] || [ -f woocommerce.php ]; then
-      # Remove untracked files/directories to ensure monorepo specific files aren't left behind
-      git clean -fxdq
-      ORIGINAL_VERSION=$(composer --version | cut -d " " -f 3)
-      if [ "${ORIGINAL_VERSION::1}" == "2" ]; then
-        echo "Switching composer version to install WooCommerce dependencies"
-        composer_self_update 1
+
+    # Directories to look for a composer.json file in
+    declare -a dirs=("$REPO_PATH" "$REPO_PATH/plugins/woocommerce")
+    for dir in "${dirs[@]}"
+    do
+     if [ -f "$dir/composer.json"  ]; then
+      $VERBOSE_OUTPUT && echo "composer.json exists at $dir/composer.json"
+      cd "$dir"
+
+      # Clean up files and then install composer dependencies
+
+      if [ -f "$dir/composer.lock" ] && [ $(git ls-files composer.lock | wc -l) -eq "0" ]; then
+        $VERBOSE_OUTPUT && echo "$dir/composer.lock is not committed to git. Deleting."
+        rm -f "$dir/composer.lock"
       fi
-      if [ -f plugins/woocommerce/woocommerce.php ]; then
-        # WooCommerce 6.0+ monorepo where composer.json is in plugins/woocommerce/composer.json
-        cd plugins/woocommerce
+
+      if [ -d "$dir/plugins" ] && [ $(git status --porcelain | grep plugins/ | wc -l) -ne "0" ]; then
+        rm -rf "$dir/plugins"
+        $VERBOSE_OUTPUT && echo "$dir/plugins from WC monorepo deleted."
+      fi
+      if [ -d "$dir/vendor" ]; then
+        $VERBOSE_OUTPUT && echo "$dir/vendor exists"
+        if [ $(git ls-files vendor | wc -l) -ne "0" ]; then
+          $VERBOSE_OUTPUT && echo "$dir/vendor is committed to git, so no composer install required. Skipping."
+          break
+        else
+          rm -rf "$dir/vendor"
+          $VERBOSE_OUTPUT && echo "$dir/vendor is not committed to git. Deleted."
+        fi
+      fi
+
+      if [ -f "$dir/composer.lock" ] && [ $(git ls-files composer.lock | wc -l) -eq "0" ]; then
+        rm -f "$dir/composer.lock"
+        $VERBOSE_OUTPUT && echo "$dir/composer.lock is not committed to git. Deleted."
       fi
       $VERBOSE_OUTPUT && echo "Install composer packages to $(pwd)" || true
       composer install --no-suggest --no-dev --quiet
       cd "$REPO_PATH"
-      NEW_VERSION=$(composer --version | cut -d " " -f 3)
-      if [ "${ORIGINAL_VERSION::1}" != "${NEW_VERSION::1}" ]; then
-        echo "Switching composer version to install WooCommerce dependencies"
-        composer_self_update rollback
-      fi
-    fi
+     fi
+    done
+
   fi
 
   # Report target

--- a/bin/gvs
+++ b/bin/gvs
@@ -39,6 +39,13 @@ environment_info() {
   echo -e "${GREEN}PHP: $YELLOW$PHP_V, ${GREEN}Xdebug: $YELLOW$XD, ${GREEN}PHPUnit: $YELLOW$PU$NC"
 }
 
+remove_uncommitted_composer_lock_file() {
+  if [ -f "$DIR/composer.lock" ] && [ $(git ls-files composer.lock | wc -l) -eq "0" ]; then
+    $VERBOSE_OUTPUT && echo "$DIR/composer.lock is not committed to git. Deleting."
+    rm -f "$DIR/composer.lock"
+  fi
+}
+
 if [ $# -lt 1 ]; then
   echo Arguments missing!
   usage_info
@@ -99,11 +106,7 @@ for REPO in "${REPOSITORIES[@]}"; do
         cd "$DIR" || exit 1
 
         # Clean up files and then install composer dependencies
-
-        if [ -f "$DIR/composer.lock" ] && [ $(git ls-files composer.lock | wc -l) -eq "0" ]; then
-          $VERBOSE_OUTPUT && echo "$DIR/composer.lock is not committed to git. Deleting."
-          rm -f "$DIR/composer.lock"
-        fi
+        remove_uncommitted_composer_lock_file
 
         if [ -d "$DIR/plugins" ] && [ $(git status --porcelain | grep plugins/ | wc -l) -ne "0" ]; then
           rm -rf "$DIR/plugins"
@@ -120,10 +123,8 @@ for REPO in "${REPOSITORIES[@]}"; do
           fi
         fi
 
-        if [ -f "$DIR/composer.lock" ] && [ $(git ls-files composer.lock | wc -l) -eq "0" ]; then
-          rm -f "$DIR/composer.lock"
-          $VERBOSE_OUTPUT && echo "$DIR/composer.lock is not committed to git. Deleted."
-        fi
+        remove_uncommitted_composer_lock_file
+
         $VERBOSE_OUTPUT && echo "Install composer packages to $(pwd)" || true
         if composer install --no-suggest --no-dev --quiet; then
           $VERBOSE_OUTPUT && echo "Composer install completed."

--- a/bin/gvs
+++ b/bin/gvs
@@ -96,23 +96,35 @@ for REPO in "${REPOSITORIES[@]}"; do
   # Checkout
   if $DO_CHECKOUT; then
     # Delete composer dependencies from WooCommerce
-    if [ -f woocommerce.php ]; then
+    if [ -f plugins/woocommerce/woocommerce.php ] || [ -f woocommerce.php ]; then
+      if [ -f plugins/woocommerce/woocommerce.php ]; then
+        # WooCommerce 6.0+ monorepo where composer.json is in plugins/woocommerce/composer.json
+        cd plugins/woocommerce
+      fi
       $VERBOSE_OUTPUT && echo "Delete composer packages from $(pwd)" || true
       rm -f composer.lock && rm -rf vendor
+      cd "$REPO_PATH"
     fi
 
     # Checkout target
     git checkout --force --quiet "$REPO_TARGET"
 
     # Install composer dependencies for WooCommerce
-    if [ -f woocommerce.php ]; then
+    if [ -f plugins/woocommerce/woocommerce.php ] || [ -f woocommerce.php ]; then
+      # Remove untracked files/directories to ensure monorepo specific files aren't left behind
+      git clean -fxdq
       ORIGINAL_VERSION=$(composer --version | cut -d " " -f 3)
       if [ "${ORIGINAL_VERSION::1}" == "2" ]; then
         echo "Switching composer version to install WooCommerce dependencies"
         composer_self_update 1
       fi
+      if [ -f plugins/woocommerce/woocommerce.php ]; then
+        # WooCommerce 6.0+ monorepo where composer.json is in plugins/woocommerce/composer.json
+        cd plugins/woocommerce
+      fi
       $VERBOSE_OUTPUT && echo "Install composer packages to $(pwd)" || true
       composer install --no-suggest --no-dev --quiet
+      cd "$REPO_PATH"
       NEW_VERSION=$(composer --version | cut -d " " -f 3)
       if [ "${ORIGINAL_VERSION::1}" != "${NEW_VERSION::1}" ]; then
         echo "Switching composer version to install WooCommerce dependencies"

--- a/bin/gvs
+++ b/bin/gvs
@@ -40,7 +40,7 @@ environment_info() {
 }
 
 composer_self_update() {
-  COMMAND="composer self-update --no-progress --$1 2>/dev/null"
+  COMMAND="composer self-update --no-progress --${1} 2>/dev/null"
   if ! $COMMAND; then
     sudo "$COMMAND"
   fi

--- a/bin/gvs
+++ b/bin/gvs
@@ -99,11 +99,11 @@ for REPO in "${REPOSITORIES[@]}"; do
     git checkout --force --quiet "$REPO_TARGET"
 
     # Directories to look for a composer.json file in
-    declare -a dirs=("$REPO_PATH" "$REPO_PATH/plugins/woocommerce")
-    for dir in "${dirs[@]}"; do
+    DIRS=("$REPO_PATH" "$REPO_PATH/plugins/woocommerce")
+    for DIR in "${DIRS[@]}"; do
       if [ -f "$dir/composer.json" ]; then
         $VERBOSE_OUTPUT && echo "composer.json exists at $dir/composer.json"
-        cd "$dir"
+        cd "$dir" || exit 1
 
         # Clean up files and then install composer dependencies
 
@@ -138,7 +138,6 @@ for REPO in "${REPOSITORIES[@]}"; do
           $VERBOSE_OUTPUT && echo "Composer install failed. Retrying with --ignore-platform-reqs."
           composer install --no-suggest --no-dev --quiet --ignore-platform-reqs
         fi
-        cd "$REPO_PATH"
       fi
     done
 

--- a/bin/gvs
+++ b/bin/gvs
@@ -137,7 +137,8 @@ for REPO in "${REPOSITORIES[@]}"; do
           $VERBOSE_OUTPUT && echo "Composer install completed."
         else
           $VERBOSE_OUTPUT && echo "Composer install failed. Retrying with --ignore-platform-reqs."
-          composer install --no-suggest --no-dev --quiet --ignore-platform-reqs
+          composer install --no-suggest --no-dev --quiet --ignore-platform-reqs --no-interaction
+          $VERBOSE_OUTPUT && echo "Alternative composer install completed."
         fi
       fi
     done

--- a/bin/gvs
+++ b/bin/gvs
@@ -45,6 +45,10 @@ remove_uncommitted_composer_lock_file() {
     rm -f "$DIR/composer.lock"
   fi
 }
+remove_vendor() {
+  rm -rf "$DIR/vendor"
+  $VERBOSE_OUTPUT && echo "$DIR/vendor deleted."
+}
 
 if [ $# -lt 1 ]; then
   echo Arguments missing!
@@ -113,13 +117,16 @@ for REPO in "${REPOSITORIES[@]}"; do
           $VERBOSE_OUTPUT && echo "$DIR/plugins from WC monorepo deleted."
         fi
         if [ -d "$DIR/vendor" ]; then
-          $VERBOSE_OUTPUT && echo "$DIR/vendor exists"
-          if [ $(git status --porcelain vendor | wc -l) -eq "0" ]; then
+          $VERBOSE_OUTPUT && echo "$DIR/vendor exists."
+          if [ ! -f "$DIR/vendor/autoload.php" ] && [ ! -f "$DIR/vendor/autoload_packages.php" ]; then
+            # Older WooCommerce versions such as 4.7.x have vendor committed, but without the necessary dependencies.
+            $VERBOSE_OUTPUT && echo "$DIR/vendor/ has no autoloader file."
+            remove_vendor
+          elif [ $(git status --porcelain vendor | wc -l) -eq "0" ]; then
             $VERBOSE_OUTPUT && echo "$DIR/vendor is committed to git, so no composer install required. Skipping."
             break
           else
-            rm -rf "$DIR/vendor"
-            $VERBOSE_OUTPUT && echo "$DIR/vendor is not committed to git. Deleted."
+            remove_vendor
           fi
         fi
 

--- a/bin/gvs
+++ b/bin/gvs
@@ -98,50 +98,48 @@ for REPO in "${REPOSITORIES[@]}"; do
     # Checkout target
     git checkout --force --quiet "$REPO_TARGET"
 
-
     # Directories to look for a composer.json file in
     declare -a dirs=("$REPO_PATH" "$REPO_PATH/plugins/woocommerce")
-    for dir in "${dirs[@]}"
-    do
-     if [ -f "$dir/composer.json"  ]; then
-      $VERBOSE_OUTPUT && echo "composer.json exists at $dir/composer.json"
-      cd "$dir"
+    for dir in "${dirs[@]}"; do
+      if [ -f "$dir/composer.json" ]; then
+        $VERBOSE_OUTPUT && echo "composer.json exists at $dir/composer.json"
+        cd "$dir"
 
-      # Clean up files and then install composer dependencies
+        # Clean up files and then install composer dependencies
 
-      if [ -f "$dir/composer.lock" ] && [ $(git ls-files composer.lock | wc -l) -eq "0" ]; then
-        $VERBOSE_OUTPUT && echo "$dir/composer.lock is not committed to git. Deleting."
-        rm -f "$dir/composer.lock"
-      fi
-
-      if [ -d "$dir/plugins" ] && [ $(git status --porcelain | grep plugins/ | wc -l) -ne "0" ]; then
-        rm -rf "$dir/plugins"
-        $VERBOSE_OUTPUT && echo "$dir/plugins from WC monorepo deleted."
-      fi
-      if [ -d "$dir/vendor" ]; then
-        $VERBOSE_OUTPUT && echo "$dir/vendor exists"
-        if [ $(git ls-files vendor | wc -l) -ne "0" ]; then
-          $VERBOSE_OUTPUT && echo "$dir/vendor is committed to git, so no composer install required. Skipping."
-          break
-        else
-          rm -rf "$dir/vendor"
-          $VERBOSE_OUTPUT && echo "$dir/vendor is not committed to git. Deleted."
+        if [ -f "$dir/composer.lock" ] && [ $(git ls-files composer.lock | wc -l) -eq "0" ]; then
+          $VERBOSE_OUTPUT && echo "$dir/composer.lock is not committed to git. Deleting."
+          rm -f "$dir/composer.lock"
         fi
-      fi
 
-      if [ -f "$dir/composer.lock" ] && [ $(git ls-files composer.lock | wc -l) -eq "0" ]; then
-        rm -f "$dir/composer.lock"
-        $VERBOSE_OUTPUT && echo "$dir/composer.lock is not committed to git. Deleted."
+        if [ -d "$dir/plugins" ] && [ $(git status --porcelain | grep plugins/ | wc -l) -ne "0" ]; then
+          rm -rf "$dir/plugins"
+          $VERBOSE_OUTPUT && echo "$dir/plugins from WC monorepo deleted."
+        fi
+        if [ -d "$dir/vendor" ]; then
+          $VERBOSE_OUTPUT && echo "$dir/vendor exists"
+          if [ $(git ls-files vendor | wc -l) -ne "0" ]; then
+            $VERBOSE_OUTPUT && echo "$dir/vendor is committed to git, so no composer install required. Skipping."
+            break
+          else
+            rm -rf "$dir/vendor"
+            $VERBOSE_OUTPUT && echo "$dir/vendor is not committed to git. Deleted."
+          fi
+        fi
+
+        if [ -f "$dir/composer.lock" ] && [ $(git ls-files composer.lock | wc -l) -eq "0" ]; then
+          rm -f "$dir/composer.lock"
+          $VERBOSE_OUTPUT && echo "$dir/composer.lock is not committed to git. Deleted."
+        fi
+        $VERBOSE_OUTPUT && echo "Install composer packages to $(pwd)" || true
+        if composer install --no-suggest --no-dev --quiet; then
+          $VERBOSE_OUTPUT && echo "Composer install completed."
+        else
+          $VERBOSE_OUTPUT && echo "Composer install failed. Retrying with --ignore-platform-reqs."
+          composer install --no-suggest --no-dev --quiet --ignore-platform-reqs
+        fi
+        cd "$REPO_PATH"
       fi
-      $VERBOSE_OUTPUT && echo "Install composer packages to $(pwd)" || true
-      if composer install --no-suggest --no-dev --quiet ; then
-        $VERBOSE_OUTPUT && echo "Composer install completed."
-      else
-        $VERBOSE_OUTPUT && echo "Composer install failed. Retrying with --ignore-platform-reqs."
-        composer install --no-suggest --no-dev --quiet --ignore-platform-reqs
-      fi
-      cd "$REPO_PATH"
-     fi
     done
 
   fi

--- a/bin/gvs
+++ b/bin/gvs
@@ -94,35 +94,35 @@ for REPO in "${REPOSITORIES[@]}"; do
     # Directories to look for a composer.json file in
     DIRS=("$REPO_PATH" "$REPO_PATH/plugins/woocommerce")
     for DIR in "${DIRS[@]}"; do
-      if [ -f "$dir/composer.json" ]; then
-        $VERBOSE_OUTPUT && echo "composer.json exists at $dir/composer.json"
-        cd "$dir" || exit 1
+      if [ -f "$DIR/composer.json" ]; then
+        $VERBOSE_OUTPUT && echo "composer.json exists at $DIR/composer.json"
+        cd "$DIR" || exit 1
 
         # Clean up files and then install composer dependencies
 
-        if [ -f "$dir/composer.lock" ] && [ $(git ls-files composer.lock | wc -l) -eq "0" ]; then
-          $VERBOSE_OUTPUT && echo "$dir/composer.lock is not committed to git. Deleting."
-          rm -f "$dir/composer.lock"
+        if [ -f "$DIR/composer.lock" ] && [ $(git ls-files composer.lock | wc -l) -eq "0" ]; then
+          $VERBOSE_OUTPUT && echo "$DIR/composer.lock is not committed to git. Deleting."
+          rm -f "$DIR/composer.lock"
         fi
 
-        if [ -d "$dir/plugins" ] && [ $(git status --porcelain | grep plugins/ | wc -l) -ne "0" ]; then
-          rm -rf "$dir/plugins"
-          $VERBOSE_OUTPUT && echo "$dir/plugins from WC monorepo deleted."
+        if [ -d "$DIR/plugins" ] && [ $(git status --porcelain | grep plugins/ | wc -l) -ne "0" ]; then
+          rm -rf "$DIR/plugins"
+          $VERBOSE_OUTPUT && echo "$DIR/plugins from WC monorepo deleted."
         fi
-        if [ -d "$dir/vendor" ]; then
-          $VERBOSE_OUTPUT && echo "$dir/vendor exists"
+        if [ -d "$DIR/vendor" ]; then
+          $VERBOSE_OUTPUT && echo "$DIR/vendor exists"
           if [ $(git ls-files vendor | wc -l) -ne "0" ]; then
-            $VERBOSE_OUTPUT && echo "$dir/vendor is committed to git, so no composer install required. Skipping."
+            $VERBOSE_OUTPUT && echo "$DIR/vendor is committed to git, so no composer install required. Skipping."
             break
           else
-            rm -rf "$dir/vendor"
-            $VERBOSE_OUTPUT && echo "$dir/vendor is not committed to git. Deleted."
+            rm -rf "$DIR/vendor"
+            $VERBOSE_OUTPUT && echo "$DIR/vendor is not committed to git. Deleted."
           fi
         fi
 
-        if [ -f "$dir/composer.lock" ] && [ $(git ls-files composer.lock | wc -l) -eq "0" ]; then
-          rm -f "$dir/composer.lock"
-          $VERBOSE_OUTPUT && echo "$dir/composer.lock is not committed to git. Deleted."
+        if [ -f "$DIR/composer.lock" ] && [ $(git ls-files composer.lock | wc -l) -eq "0" ]; then
+          rm -f "$DIR/composer.lock"
+          $VERBOSE_OUTPUT && echo "$DIR/composer.lock is not committed to git. Deleted."
         fi
         $VERBOSE_OUTPUT && echo "Install composer packages to $(pwd)" || true
         if composer install --no-suggest --no-dev --quiet; then

--- a/bin/gvs
+++ b/bin/gvs
@@ -39,13 +39,6 @@ environment_info() {
   echo -e "${GREEN}PHP: $YELLOW$PHP_V, ${GREEN}Xdebug: $YELLOW$XD, ${GREEN}PHPUnit: $YELLOW$PU$NC"
 }
 
-composer_self_update() {
-  COMMAND="composer self-update --no-progress --${1} 2>/dev/null"
-  if ! $COMMAND; then
-    sudo "$COMMAND"
-  fi
-}
-
 if [ $# -lt 1 ]; then
   echo Arguments missing!
   usage_info


### PR DESCRIPTION
Related to wcz/pr510

Makes composer install support more generic. Now a `composer install` is run for any checkout that contains a `composer.json` file.  Previously `composer install` was only run for WooCommerce directories only.

Also adds support for WooCommerce 6.0+'s monorepo structure, where the composer.json file is in a `plugins/woocommerce` subdirectory.

These changes allow our CI's to support the upcoming WooCommerce v6, as well as the upcoming WooCommerce Subscriptions v4 (which has composer dependencies).

This PR also removes the need to revert to composer v1 and back again when installing WooCommerce dependencies.