### PR TITLE
Tweaks for v1.3.1 release

### DIFF
--- a/README.md
+++ b/README.md
@@ -25,7 +25,7 @@ Example: `path/to/repo:1.2.3-beta.1`
 **Notes:**
 - You can use relative, absolute and home (~) paths.
 - If you were using a global variable for path, wrap it in curly braces ({}) to avoid interpreting the colon by the shell. Example: `${MY_PATH}:0.1.0`
-- This script reinstalls composer dependencies upon version switch if a target repository is [WooCommerce](https://github.com/woocommerce/woocommerce).
+- This script installs composer dependencies upon version switch if a target contains a `composer.json` file in the root directory or in the `plugins/woocommerce/` subdirectory.
 
 ## Installation
 

--- a/README.md
+++ b/README.md
@@ -14,7 +14,8 @@ Usage: gvs [-h] [-u] [-r] [-v] <TARGET1> [TARGET2…]
    -u | --update        Update default remote (fetch)
    -r | --report-only   Discard version switching, only report
    -v | --verbose       Verbose output
-   TARGET               Path and branch|commit|tag separated by a colon (:)
+   -V | --version       Display version
+   TARGET               A path and a branch|commit|tag separated by a colon (:)
 ```
 
 For 'target', pass one or more path and branch|commit|tag separated by a colon (:) to specify a target. The first part should be a path to a git repository; the second part is the target branch|commit|tag.

--- a/bin/gvs
+++ b/bin/gvs
@@ -126,48 +126,50 @@ while [ -n "$1" ]; do
   shift
 done
 
-for REPO in "${REPOSITORIES[@]}"; do
-  # Split param
-  REPO_PATH=$(echo "$REPO" | cut -f1 -d':')
-  REPO_TARGET=$(echo "$REPO" | cut -f2 -d':')
+if [ ${#REPOSITORIES[@]} -ne 0 ]; then
+  for REPO in "${REPOSITORIES[@]}"; do
+    # Split param
+    REPO_PATH=$(echo "$REPO" | cut -f1 -d':')
+    REPO_TARGET=$(echo "$REPO" | cut -f2 -d':')
 
-  # Test path
-  if [ ! -d "$REPO_PATH" ]; then
-    echo "Target path ($REPO_PATH) not exists. Aborting"
-    exit 1
-  fi
+    # Test path
+    if [ ! -d "$REPO_PATH" ]; then
+      echo "Target path ($REPO_PATH) not exists. Aborting"
+      exit 1
+    fi
 
-  cd "$REPO_PATH" || exit 1
+    cd "$REPO_PATH" || exit 1
 
-  # Update (fetch)
-  if $DO_UPDATE; then
-    verbose_only_echo "Update from remote (fetch) for $(pwd)"
-    git fetch --tags --force
-  fi
+    # Update (fetch)
+    if $DO_UPDATE; then
+      verbose_only_echo "Update from remote (fetch) for $(pwd)"
+      git fetch --tags --force
+    fi
 
-  # Checkout
-  if $DO_CHECKOUT; then
-    # Temporary store wp-tests-config.php content
-    collect_wp_test_config
+    # Checkout
+    if $DO_CHECKOUT; then
+      # Temporary store wp-tests-config.php content
+      collect_wp_test_config
 
-    # Reset to clean state.
-    # See: https://stackoverflow.com/a/1090316
-    git reset --hard
-    git clean -fxd
+      # Reset to clean state.
+      # See: https://stackoverflow.com/a/1090316
+      git reset --hard
+      git clean -fxd
 
-    # Restore wp-tests-config.php if previously stored.
-    restore_wp_test_config
+      # Restore wp-tests-config.php if previously stored.
+      restore_wp_test_config
 
-    # Checkout target
-    git checkout --force --quiet "$REPO_TARGET"
+      # Checkout target
+      git checkout --force --quiet "$REPO_TARGET"
 
-    composer_install
-  fi
+      composer_install
+    fi
 
-  # Report target
-  REPO_HEAD=$(git describe --tags --always)
-  echo -e "$CYAN$(pwd): $YELLOW$REPO_HEAD$NC "
-done
+    # Report target
+    REPO_HEAD=$(git describe --tags --always)
+    echo -e "$CYAN$(pwd): $YELLOW$REPO_HEAD$NC "
+  done
+fi
 
 if $VERBOSE_OUTPUT; then
   echo_environment_info

--- a/bin/gvs
+++ b/bin/gvs
@@ -59,6 +59,7 @@ function restore_wp_test_config() {
   if [ ! ${#WP_TEST_CONFIG} -eq 0 ]; then
     echo "Restore wp-tests-config.php."
     echo "$WP_TEST_CONFIG" >wp-tests-config.php
+    WP_TEST_CONFIG=""
   fi
 }
 

--- a/bin/gvs
+++ b/bin/gvs
@@ -88,7 +88,7 @@ function composer_install() {
 
   if ! composer install --no-interaction --no-dev --quiet; then
     verbose_only_echo "Composer install failed. Retrying with \`--ignore-platform-reqs.\`"
-    composer install --no-interaction --no-dev --quiet --ignore-platform-reqs --no-interaction
+    composer install --no-interaction --no-dev --quiet --ignore-platform-reqs
     verbose_only_echo "Alternative composer install completed."
   fi
 

--- a/bin/gvs
+++ b/bin/gvs
@@ -43,7 +43,7 @@ function get_phpunit_version() {
 
 function echo_environment_info() {
   PHP_V=$(php -r "echo PHP_VERSION, \"\n\";")
-  if php -i | grep -q "xdebug support"; then XD=enabled; else XD=disabled; fi
+  if php -v | grep -qi "xdebug"; then XD=enabled; else XD=disabled; fi
   PU=$(get_phpunit_version)
   echo -e "${GREEN}PHP: $YELLOW$PHP_V, ${GREEN}Xdebug: $YELLOW$XD, ${GREEN}PHPUnit: $YELLOW$PU$NC"
 }


### PR DESCRIPTION
Notable changes:

### Changed:
-  Allow running `gvs -v` alone to return generic env info. Example output: `PHP: 7.4.33, Xdebug: enabled, PHPUnit: 9.6.3`
- Detect Xdebug v3.x correctly

### Fixed: 
- No longer create `wp-tests-config.php` files in unrelated repositories
- Make sure the restored `wp-tests-config.php` file contains the proper data
